### PR TITLE
Corrected framerate options

### DIFF
--- a/video_drivers/FFMPEG.js
+++ b/video_drivers/FFMPEG.js
@@ -86,8 +86,8 @@ class FFMPEG {
 		this.robot.getVideoPort()
 		.then(({ mpeg_stream_port }) => {
 			this.video = exec(format('%s ' + //CMD
-					'-f v4l2 -framerate 25 -video_size 640x480 -i /dev/video%d '+ //Input
-					'-f mpegts -codec:v mpeg1video -s 640x480 -b:v %dk -bf 0 -muxdelay 0.001 %s http://%s:%s/%s/640/480/', //Output 
+					'-f v4l2 -video_size 640x480 -i /dev/video%d '+ //Input
+					'-f mpegts -r 30 -codec:v mpeg1video -s 640x480 -b:v %dk -bf 0 -muxdelay 0.001 %s http://%s:%s/%s/640/480/', //Output 
 					cmd, this.config.videoDeviceNumber, this.config.kbps, buildFilterCli(this.config, this.getFile), server, mpeg_stream_port, streamkey), {shell: '/bin/bash'},
 					(err, stdout, stderr) => {
 						if (err){


### PR DESCRIPTION
Using -framerate 25 on cameras that can only do 15/30 will cause most cameras to output 15 fps.
Forcing 30 fps on the output will allow any framerate input without the browser player crashing.